### PR TITLE
Github ActionとGithub Pagesによるデプロイを追加

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,31 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+      - feature/add_github_action_deploy
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4.0.0
+
+      - name: Copy static files
+        run: |
+          mkdir public
+          cp -r tatehamawebapp/* public/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3.0.1
+        with:
+          path: ./public
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4.0.5

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/add_github_action_deploy
 
 jobs:
   deploy:


### PR DESCRIPTION
# マージ前にやること
「Settings」->「Pages」 -> Sourceを「Github Actions」に変更する

これで最低限、デプロイが自動でできるはず

# Custom Domains
(まだCloudflare側未対応のため、対応後設定変更すること)
Custom domainに `tatehama.jp` を入れてSave
だいたい15分(ドキュメントによれば最大でも24時間)ぐらいで切り替わる